### PR TITLE
Update "try Cognitive Services for free" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You will also need to setup some cloud services.
    - Click **Overview** and copy **Endpoint** to a text file (you will use this later)
    - Click **Keys** and copy **KEY 1** to a text file (you will use this later)
 
-** You should hold off doing this until a few days before the tutorial, because free keys expire after one week. Otherwise, you might have to refresh your keys beforehand, which can take up to 10 minutes.
+** [Create a new Azure account, and try Cognitive Services for free.](https://azure.microsoft.com/free/cognitive-services/)
 
 # Demos
 


### PR DESCRIPTION
I removed the text "You should hold off doing this until a few days before the tutorial, because free keys expire after one week. Otherwise, you might have to refresh your keys beforehand, which can take up to 10 minutes." and replaced it with a link to the Cognitive Services Web site. Currently the trial period is 12 months, though that might change again in the future.